### PR TITLE
存在しないURLを修正

### DIFF
--- a/download.html
+++ b/download.html
@@ -86,7 +86,7 @@
 				<p>Antergos はフリー (無料・自由) な OS です。自由にダウンロードとコピーの作成ができます。 ISO イメージをダウンロードして、 CD や DVD 、または USB メモリに書き込むだけで簡単に楽しめます。</p>
 				<p>ISO イメージは、毎回起動時に Cnchi (インストーラ) を最新版に更新します。</p>
 			<div class="alert alert-info">
-				<p>Antergos の LiveUSB を作成するために推奨する方法を Wiki にまとめています: <a href="http://wiki.antergos.com/Create+a+working+Live+USB">HOW TO: Create a working Live USB</a></p>
+				<p>Antergos の LiveUSB を作成するために推奨する方法を Wiki にまとめています: <a href="https://antergos.com/wiki/ja/install/create-a-working-live-usb/">HOW TO: Create a working Live USB</a></p>
 			</div>
 			<hr>
 			<h3>安定版のダウンロード</h3>


### PR DESCRIPTION
LiveUSBの作成方法を示したwikiのページが存在しなかったため、現在のものに差し替えました。